### PR TITLE
fix shebang

### DIFF
--- a/scripts/autotest
+++ b/scripts/autotest
@@ -1,4 +1,4 @@
-#! /usr/bin/env perl
+#! perl
 # ABSTRACT: run Perl5 test programs as soon as they are modified or created
 # PODNAME: autotest
 


### PR DESCRIPTION
Unfortunately, MakeMaker's fixin function does not fix the
shebang correctly if it reads "#! /usr/bin/env perl". If it's
changed to "#! /usr/bin/perl" or just "#!perl", then it works.

Demonstration:
· using system perl:

```
$ perl Makefile.PL && make
$ head -1 blib/script/autotest 
#! /usr/bin/env perl
```

→ This probably does not matter, as the system perl is usually in the `PATH`.

· using custom perl (not in `PATH`):

```
$ /opt/perl-5.18.2/bin/perl Makefile.PL && make
$ head -1 blib/script/autotest 
#! /usr/bin/env perl
```

→ This would not work.

· after the fix:

```
$  /opt/perl-5.18.2/bin/perl Makefile.PL && make
$ head -1 blib/script/autotest 
#!/opt/perl-5.18.2/bin/perl
```

· and system perl would also work:

```
$ perl Makefile.PL && make
$ head -1 blib/script/autotest 
#!/usr/bin/perl
```
